### PR TITLE
chore: 🤖 bump up to v0.106.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-mock-tx-types"
 description = "CKB mock transaction types"
-version = "0.105.1"
+version = "0.106.0"
 license = "MIT"
 edition = "2021"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
@@ -9,8 +9,8 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = "0.105.1"
-ckb-jsonrpc-types = "0.105.1"
-ckb-traits = "0.105.1"
+ckb-types = "0.106.0"
+ckb-jsonrpc-types = "0.106.0"
+ckb-traits = "0.106.0"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
### What does this PR do?
-   Use new released ckb 0.106.0